### PR TITLE
Exit script on errors

### DIFF
--- a/installproot.sh
+++ b/installproot.sh
@@ -1,6 +1,11 @@
 #!/data/data/com.termux/files/usr/bin/env sh
 # Download and install proot alpine (WIP)
 
+# safety
+set -o pipefail
+shopt -s failglob
+set -u
+
 # setting env var
 arch=$(dpkg --print-architecture)
 username="user"


### PR DESCRIPTION
Check for environment variables, failed globs and failed commands and exit to avoid unwanted behavior